### PR TITLE
Rename RSSlink to RSSLink

### DIFF
--- a/layouts/partials/base/metas.html
+++ b/layouts/partials/base/metas.html
@@ -62,8 +62,8 @@
 </script>
 {{ end }}
 
-{{ if .RSSlink }}
-<link href="{{ .RSSlink }}" rel="alternate" type="application/rss+xml" title="{{ .Title }}" />
+{{ if .RSSLink }}
+<link href="{{ .RSSLink }}" rel="alternate" type="application/rss+xml" title="{{ .Title }}" />
 {{ end }}
 <link rel="canonical" href="{{ .Permalink }}" />
 

--- a/layouts/partials/modules/site/link/social/rss.html
+++ b/layouts/partials/modules/site/link/social/rss.html
@@ -1,4 +1,4 @@
 {{ if .Site.Params.rss }}
-<a id="contact-link-rss" class="contact_link" href="{{ .RSSlink }}" type="application/rss+xml">
+<a id="contact-link-rss" class="contact_link" href="{{ .RSSLink }}" type="application/rss+xml">
   <span class="fa fa-rss-square"></span><span>rss</span></a>
 {{ end }}


### PR DESCRIPTION
The former will be deprecated and eventually removed from Hugo.

Note: Currently both of them exist in Hugo, which is the reason for the cleanup.