### PR TITLE
Use relative URLs

### DIFF
--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -4,11 +4,10 @@
     {{ partial "content/h1-title" . }}
   </header>
   <ul class="container content">
-  {{ $baseurl := .Site.BaseURL }}
   {{ $data := .Data }}
   {{ range $key,$value := .Data.Terms.ByCount }}
     <li>
-      <a href="{{ $baseurl }}{{ $data.Plural }}/{{ $value.Name | urlize }}">
+      <a href="{{ (print $data.Plural "/" ($value.Name | urlize) "/") | relURL }}">
         {{ $value.Name }}
       </a>
       <strong>

--- a/layouts/partials/base/scripts.html
+++ b/layouts/partials/base/scripts.html
@@ -3,7 +3,7 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.11.0/umd/popper.min.js" integrity="sha384-b/U6ypiBEHpOf/4+1nzFpr53nxSS+GLCkfwBdFNTxtclqqenISfwAzpKaMNFNmj4" crossorigin="anonymous"></script>
 <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta/js/bootstrap.min.js" integrity="sha384-h0AbiXch4ZDo7tp9hKZ4TsHbi047NrKGLO3SEJAg45jXxnGIfYzk4Si90RDIqNm1" crossorigin="anonymous"></script>
 
-<script src="{{ .Site.BaseURL }}assets/js/highlight.pack.js"></script>
+<script src="{{ "assets/js/highlight.pack.js" | relURL }}"></script>
 
 <script>hljs.initHighlightingOnLoad();</script>
 
@@ -11,7 +11,7 @@
 <script id="dsq-count-scr" src="//{{ . }}.disqus.com/count.js" async></script>
 {{ end }}
 
-<script src="{{ .Site.BaseURL }}assets/js/script.js"></script>
+<script src="{{ "assets/js/script.js" | relURL }}"></script>
 
 {{ template "_internal/google_analytics_async.html" . }}
 

--- a/layouts/partials/content/pagination.html
+++ b/layouts/partials/content/pagination.html
@@ -4,14 +4,14 @@
       {{ if or (.Paginator.HasPrev) (.Paginator.HasNext) }}
           {{ if .Paginator.HasPrev }}
             <li class="page-item">
-              <a class="page-link" rel="prev" href="{{ .Site.BaseURL }}{{.Paginator.Prev.URL}}">
+              <a class="page-link" rel="prev" href="{{ .Paginator.Prev.URL | relURL }}">
                   « Previous
               </a>
             </li>
           {{ end }}
           {{ if .Paginator.HasNext }}
             <li class="page-item">
-              <a class="page-link" rel="next" href="{{ .Site.BaseURL }}{{.Paginator.Next.URL}}">
+              <a class="page-link" rel="next" href="{{ .Paginator.Next.URL | relURL }}">
                   Next »
               </a>
             </li>

--- a/layouts/partials/content/post-meta.html
+++ b/layouts/partials/content/post-meta.html
@@ -16,7 +16,7 @@
       <div class="post-meta-item">
           <i class="fa fa-folder-open-o"></i>
           {{ range $k, $v := .Params.categories }}
-          <a class="article-category-link" href="{{ $.Site.BaseURL }}categories/{{ . | urlize | lower }}">{{ . }}</a>
+          <a class="article-category-link" href="{{ (print "categories/" (. | urlize | lower) "/") | relURL }}">{{ . }}</a>
           {{ if lt $k (sub $categoriesLen 1) }}&middot;{{ end }}
           {{ end }}
       </div>
@@ -29,7 +29,7 @@
         <div class="post-meta-item">
           <i class="fa fa-tags"></i>
           {{ range $k, $v := .Params.tags }}
-          <a href="{{ $.Site.BaseURL }}tags/{{ . | urlize | lower }}/">{{ . }}</a>
+          <a href="{{ (print "tags/" (. | urlize | lower) "/") | relURL }}">{{ . }}</a>
           {{ if lt $k (sub $tagsLen 1) }}&middot;{{ end }}
           {{ end }}
         </div>

--- a/layouts/partials/content/title-banner.html
+++ b/layouts/partials/content/title-banner.html
@@ -3,7 +3,7 @@
     {{if or (in (substr .Params.banner 0 7) "http://") (in (substr .Params.banner 0 8) "https://")}}
       <img src="{{ .Params.banner }}" class="img-fluid" alt="Generic responsive image">
     {{ else }}
-      <img src="{{ .Site.BaseURL }}{{ .Params.banner }}" class="img-fluid" alt="Generic responsive image">
+      <img src="{{ .Params.banner | relURL }}" class="img-fluid" alt="Generic responsive image">
     {{end}}
 </a>
 {{ end }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -7,9 +7,9 @@
 
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta/css/bootstrap.min.css" integrity="sha384-/Y6pD6FV/Vv2HJnA6t+vslU6fwYXjCFtcEpHbNJ0lyAFsXTsjBbfaDjzALeQsN6M" crossorigin="anonymous">
 
-  <link rel="stylesheet" href="{{ .Site.BaseURL }}assets/css/font-awesome.min.css">
-  <link rel="stylesheet" href="{{ .Site.BaseURL }}assets/css/style.css">
-  <link rel="stylesheet" href="{{ .Site.BaseURL }}assets/css/tomorrow-night.css">
+  <link rel="stylesheet" href="{{ "assets/css/font-awesome.min.css" | relURL }}">
+  <link rel="stylesheet" href="{{ "assets/css/style.css" | relURL }}">
+  <link rel="stylesheet" href="{{ "assets/css/tomorrow-night.css" | relURL }}">
   <link href='//fonts.googleapis.com/css?family=Source+Code+Pro' rel='stylesheet' type='text/css'>
 
 </head>

--- a/layouts/partials/widgets/categories.html
+++ b/layouts/partials/widgets/categories.html
@@ -8,7 +8,7 @@
       <ul>
         {{ range $name, $items := .Site.Taxonomies.categories }}
         <li class="category-list-item">
-            <a href="{{ $.Site.BaseURL }}categories/{{ $name | urlize | lower }}">
+            <a href="{{ (print "categories/" ($name | urlize | lower) "/") | relURL }}">
                 {{ $name }}
             </a>
             <span class="category-list-count">{{ len $items }}</span>

--- a/layouts/partials/widgets/recent_articles.html
+++ b/layouts/partials/widgets/recent_articles.html
@@ -13,7 +13,7 @@
                   <span style="background-image:url({{ .Params.banner }})"
                     alt="{{ .Title | markdownify }}" class="thumbnail-image"></span>
                   {{ else }}
-                  <span style="background-image:url({{ $.Site.BaseURL }}{{ .Params.banner }})"
+                  <span style="background-image:url({{ .Params.banner | relURL }})"
                     alt="{{ .Title | markdownify }}" class="thumbnail-image"></span>
                   {{end}}
               {{else}}

--- a/layouts/partials/widgets/tag_cloud.html
+++ b/layouts/partials/widgets/tag_cloud.html
@@ -5,7 +5,7 @@
   <h4 class="card-title">TAG CLOUD</h4>
   <p class="card-text">
     {{ range $name, $items := .Site.Taxonomies.tags }}
-        <a href="{{ $.Site.BaseURL }}tags/{{ $name | urlize | lower  }}/" class="badge badge-primary">
+        <a href="{{ (print "tags/" ($name | urlize | lower) "/") | relURL }}" class="badge badge-primary">
         {{ $name }}
         </a>
     {{ end }}

--- a/layouts/partials/widgets/tags.html
+++ b/layouts/partials/widgets/tags.html
@@ -9,7 +9,7 @@
       <ul>
         {{ range $name, $items := .Site.Taxonomies.tags }}
           <li>
-            <a href="{{ $.Site.BaseURL }}tags/{{ $name | urlize | lower  }}/">{{ $name }}</a>
+            <a href="{{ (print "tags/" ($name | urlize | lower) "/") | relURL }}">{{ $name }}</a>
             <span class="category-list-count">{{ len $items }}</span>
           </li>
         {{ end }}

--- a/layouts/taxonomy/topic.terms.html
+++ b/layouts/taxonomy/topic.terms.html
@@ -3,12 +3,11 @@
   <header class="container">
     {{ partial "content/h1-title" . }}
   </header>
-  {{ $baseurl := .Site.BaseURL }}
   {{ $data := .Data }}
   {{ range $key,$value := .Data.Terms.Alphabetical }}
   <article class="container">
     <h2>
-      <a href="{{ $baseurl }}{{ $data.Plural }}/{{ $value.Name | urlize }}">{{ $value.Name }}</a>
+      <a href="{{ (print $data.Plural "/" ($value.Name | urlize) "/") | relURL }}">{{ $value.Name }}</a>
     </h2>
     <ul>
       {{ range $value.Pages.ByTitle }}


### PR DESCRIPTION
Incorporate use of `relURL` and `print` functions to allow for configuration flexibility with relative URLs.

This update was in response to the Hugo discussion entitled "[Bootstrap theme is complete via ‘hugo serve’ but incomplete via s3 hosting](https://discourse.gohugo.io/t/bootstrap-theme-is-complete-via-hugo-serve-but-incomplete-via-s3-hosting/8157)".